### PR TITLE
Add requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,15 @@
+# Required python modules 
+# pip install -r requirements.txt 
+
+pyttsx3
+SpeechRecognition
+pyaudio
+pywhatkit
+yfinance
+pyjokes
+git+https://github.com/openai/whisper.git
+gradio
+youtube-search-python
+
+# MacOS seems to need this for pyttsx3
+pyobjc == 9.0.1


### PR DESCRIPTION
Add a requirements.txt file for easy `pip install -r requirements.txt ` run.

Also, added `pyobjc == 9.0.1` which seems to be required to fix compat issue with pyttsx3 on MacOS.